### PR TITLE
Add shader that renders textures from a sprite sheet using instanced rendering

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,14 +1,28 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <iostream>
+#include "vao.h"
 
 const char* vertexShaderSource = "#version 330 core\n"
 "layout (location = 0) in vec3 aPos;\n"
+"layout (location = 1) in vec2 aTexCoord;\n"
+"layout (location = 2) in vec2 aOffset;\n"
+"out vec2 TexCoord;\n"
 "void main()\n"
 "{\n"
-"   gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);\n"
+"   TexCoord = aTexCoord;\n"
+"   vec3 pos = aPos + vec3(aOffset, 0.0);\n"
+"   gl_Position = vec4(pos, 1.0);\n"
 "}\0";
 
+const char* fragmentShaderSource = "#version 330 core\n"
+"in vec2 TexCoord;\n"
+"out vec4 FragColor;\n"
+"uniform sampler2D spriteSheet;\n"
+"void main()\n"
+"{\n"
+"   FragColor = texture(spriteSheet, TexCoord);\n"
+"}\0";
 
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
@@ -48,6 +62,51 @@ int main() {
 	// Set viewport size every time window is resized
 	glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
 
+	// Build and compile shaders
+	unsigned int vertexShader = glCreateShader(GL_VERTEX_SHADER);
+	glShaderSource(vertexShader, 1, &vertexShaderSource, NULL);
+	glCompileShader(vertexShader);
+
+	unsigned int fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+	glShaderSource(fragmentShader, 1, &fragmentShaderSource, NULL);
+	glCompileShader(fragmentShader);
+
+	unsigned int shaderProgram = glCreateProgram();
+	glAttachShader(shaderProgram, vertexShader);
+	glAttachShader(shaderProgram, fragmentShader);
+	glLinkProgram(shaderProgram);
+
+	glDeleteShader(vertexShader);
+	glDeleteShader(fragmentShader);
+
+	// Set up vertex data and buffers and configure vertex attributes
+	unsigned int VAO, VBO, EBO;
+	createQuadVAO(VAO, VBO, EBO);
+
+	// Load and create a texture
+	unsigned int texture;
+	glGenTextures(1, &texture);
+	glBindTexture(GL_TEXTURE_2D, texture);
+	// Set texture wrapping parameters
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	// Set texture filtering parameters
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	// Load image, create texture and generate mipmaps
+	int width, height, nrChannels;
+	unsigned char* data = stbi_load("path/to/spritesheet.png", &width, &height, &nrChannels, 0);
+	if (data)
+	{
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		glGenerateMipmap(GL_TEXTURE_2D);
+	}
+	else
+	{
+		std::cout << "Failed to load texture" << std::endl;
+	}
+	stbi_image_free(data);
+
 	// Render loop
 	while (!glfwWindowShouldClose(window))
 	{
@@ -57,6 +116,14 @@ int main() {
 		// Rendering commands here
 		glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
+
+		// Bind texture
+		glBindTexture(GL_TEXTURE_2D, texture);
+
+		// Render container
+		glUseProgram(shaderProgram);
+		glBindVertexArray(VAO);
+		glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, 100);
 
 		// Check and call events and swap buffers
 		glfwSwapBuffers(window);

--- a/main.cpp
+++ b/main.cpp
@@ -1,28 +1,9 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <iostream>
+#include <fstream>
+#include <sstream>
 #include "vao.h"
-
-const char* vertexShaderSource = "#version 330 core\n"
-"layout (location = 0) in vec3 aPos;\n"
-"layout (location = 1) in vec2 aTexCoord;\n"
-"layout (location = 2) in vec2 aOffset;\n"
-"out vec2 TexCoord;\n"
-"void main()\n"
-"{\n"
-"   TexCoord = aTexCoord;\n"
-"   vec3 pos = aPos + vec3(aOffset, 0.0);\n"
-"   gl_Position = vec4(pos, 1.0);\n"
-"}\0";
-
-const char* fragmentShaderSource = "#version 330 core\n"
-"in vec2 TexCoord;\n"
-"out vec4 FragColor;\n"
-"uniform sampler2D spriteSheet;\n"
-"void main()\n"
-"{\n"
-"   FragColor = texture(spriteSheet, TexCoord);\n"
-"}\0";
 
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
@@ -33,6 +14,14 @@ void processInput(GLFWwindow* window)
 {
 	if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
 		glfwSetWindowShouldClose(window, true);
+}
+
+std::string readShaderSource(const std::string& filePath)
+{
+	std::ifstream shaderFile(filePath);
+	std::stringstream shaderStream;
+	shaderStream << shaderFile.rdbuf();
+	return shaderStream.str();
 }
 
 int main() {
@@ -63,12 +52,18 @@ int main() {
 	glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
 
 	// Build and compile shaders
+	std::string vertexShaderSource = readShaderSource("shaders/vertex_shader.glsl");
+	std::string fragmentShaderSource = readShaderSource("shaders/fragment_shader.glsl");
+
+	const char* vertexShaderCode = vertexShaderSource.c_str();
+	const char* fragmentShaderCode = fragmentShaderSource.c_str();
+
 	unsigned int vertexShader = glCreateShader(GL_VERTEX_SHADER);
-	glShaderSource(vertexShader, 1, &vertexShaderSource, NULL);
+	glShaderSource(vertexShader, 1, &vertexShaderCode, NULL);
 	glCompileShader(vertexShader);
 
 	unsigned int fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
-	glShaderSource(fragmentShader, 1, &fragmentShaderSource, NULL);
+	glShaderSource(fragmentShader, 1, &fragmentShaderCode, NULL);
 	glCompileShader(fragmentShader);
 
 	unsigned int shaderProgram = glCreateProgram();

--- a/shaders/fragment_shader.glsl
+++ b/shaders/fragment_shader.glsl
@@ -1,0 +1,8 @@
+#version 330 core
+in vec2 TexCoord;
+out vec4 FragColor;
+uniform sampler2D spriteSheet;
+void main()
+{
+    FragColor = texture(spriteSheet, TexCoord);
+}

--- a/shaders/vertex_shader.glsl
+++ b/shaders/vertex_shader.glsl
@@ -1,0 +1,13 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec2 aTexCoord;
+layout (location = 2) in vec2 aOffset;
+
+out vec2 TexCoord;
+
+void main()
+{
+    TexCoord = aTexCoord;
+    vec3 pos = aPos + vec3(aOffset, 0.0);
+    gl_Position = vec4(pos, 1.0);
+}

--- a/vao.cpp
+++ b/vao.cpp
@@ -1,0 +1,37 @@
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+void createQuadVAO(unsigned int& VAO, unsigned int& VBO, unsigned int& EBO) {
+    float vertices[] = {
+        // positions        // texture coords
+         0.5f,  0.5f, 0.0f,  1.0f, 1.0f,
+         0.5f, -0.5f, 0.0f,  1.0f, 0.0f,
+        -0.5f, -0.5f, 0.0f,  0.0f, 0.0f,
+        -0.5f,  0.5f, 0.0f,  0.0f, 1.0f
+    };
+    unsigned int indices[] = {
+        0, 1, 3,
+        1, 2, 3
+    };
+
+    glGenVertexArrays(1, &VAO);
+    glGenBuffers(1, &VBO);
+    glGenBuffers(1, &EBO);
+
+    glBindVertexArray(VAO);
+
+    glBindBuffer(GL_ARRAY_BUFFER, VBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(0);
+
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
+    glEnableVertexAttribArray(1);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+}

--- a/vao.h
+++ b/vao.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void createQuadVAO(unsigned int& VAO, unsigned int& VBO, unsigned int& EBO);


### PR DESCRIPTION
Fixes #1

Add shader and VAO for rendering textures from a sprite sheet using instanced rendering.

* **Shaders**:
  - Add vertex shader code in `main.cpp` to handle texture coordinates and instanced rendering.
  - Add fragment shader code in `main.cpp` to handle texture sampling from the sprite sheet.
  - Add new vertex shader file `shaders/vertex_shader.glsl`.
  - Add new fragment shader file `shaders/fragment_shader.glsl`.

* **VAO**:
  - Add `vao.cpp` to create a VAO with a quad mesh for rendering textures.
  - Add `vao.h` header file for VAO creation.

* **Rendering Loop**:
  - Update the rendering loop in `main.cpp` to use the new shaders and VAO for instanced rendering.
  - Add code to load and create a texture from a sprite sheet in `main.cpp`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JaryJay/opengl-cpp/issues/1?shareId=3c8297d3-fcce-49e2-977d-c571592ed207).